### PR TITLE
Remove the (apparently useless) statusbar

### DIFF
--- a/partwin.cpp
+++ b/partwin.cpp
@@ -96,7 +96,7 @@ void PartWin::setupPart() {
 	
 	setupActions();
 
-	setupGUI(ToolBar | Keys | StatusBar | Save);
+	setupGUI(ToolBar | Keys | Save);
 	toolBar("okularToolBar")->setToolButtonStyle(Qt::ToolButtonIconOnly);
 	
 	// integrate the part's GUI with the shell's


### PR DESCRIPTION
The statusbar doesn't seem to be used by the okular kpart, remove it. This saves some vertical space, and makes okularplugin another little bit better than kpartsplugin.
Before: http://s13.postimg.org/ne0s0qjjb/before.png
After: http://s13.postimg.org/86pdu4h2f/after.png
